### PR TITLE
fix(ci): garde merged sur le job deploy-backoffice

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -48,6 +48,7 @@ jobs:
   deploy-backoffice:
     name: Deploy Backoffice → Clever Cloud
     runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Problème

Dans `.github/workflows/deploy-main.yml`, le job `deploy-backoffice` ne portait pas le garde `if: github.event.pull_request.merged == true` présent sur `deploy-api` et `deploy-frontend`.

Le workflow se déclenchant sur `pull_request: [closed]`, le backoffice se serait donc redéployé sur Clever Cloud **même lors de la fermeture d'une PR sans merge**, à partir de code non intégré.

## Correctif

Ajout du même garde que les deux autres jobs, pour que les 3 déploiements ne se lancent qu'en cas de merge effectif.

## Notes

- Modification d'une seule ligne, alignement avec les jobs existants.
- La doc `docs/plan_deploiement.md` est déjà à jour sur `dev` (v1.1.0), aucune modification de doc nécessaire.