### PR TITLE
Promotion staging → main : CD Clever Cloud (déploiements manuels + garde)

### DIFF
--- a/.clever.json
+++ b/.clever.json
@@ -23,6 +23,30 @@
       "git_ssh_url": "git+ssh://git@push-n3-par-clevercloud-customers.services.clever-cloud.com/app_da5f981d-0c8f-4452-b97b-0fe976de51f8.git",
       "name": "[PipouJS] Backoffice",
       "alias": "PipouJS-Backoffice"
+    },
+    {
+      "app_id": "app_f0c2c11d-7d3c-4a07-9c4c-be5d7ded7e56",
+      "org_id": "user_fef9b663-1327-4ea5-99ba-33058123e8e0",
+      "deploy_url": "https://push-n3-par-clevercloud-customers.services.clever-cloud.com/app_f0c2c11d-7d3c-4a07-9c4c-be5d7ded7e56.git",
+      "git_ssh_url": "git+ssh://git@push-n3-par-clevercloud-customers.services.clever-cloud.com/app_f0c2c11d-7d3c-4a07-9c4c-be5d7ded7e56.git",
+      "name": "[PipouJS] API staging",
+      "alias": "PipouJS-API-staging"
+    },
+    {
+      "app_id": "app_5348364e-901f-426f-973f-0125813ee198",
+      "org_id": "user_fef9b663-1327-4ea5-99ba-33058123e8e0",
+      "deploy_url": "https://push-n3-par-clevercloud-customers.services.clever-cloud.com/app_5348364e-901f-426f-973f-0125813ee198.git",
+      "git_ssh_url": "git+ssh://git@push-n3-par-clevercloud-customers.services.clever-cloud.com/app_5348364e-901f-426f-973f-0125813ee198.git",
+      "name": "[PipouJS] Front staging",
+      "alias": "PipouJS-Front-staging"
+    },
+    {
+      "app_id": "app_d18dc07c-dfa4-4495-b031-6154fb63aedd",
+      "org_id": "user_fef9b663-1327-4ea5-99ba-33058123e8e0",
+      "deploy_url": "https://push-n3-par-clevercloud-customers.services.clever-cloud.com/app_d18dc07c-dfa4-4495-b031-6154fb63aedd.git",
+      "git_ssh_url": "git+ssh://git@push-n3-par-clevercloud-customers.services.clever-cloud.com/app_d18dc07c-dfa4-4495-b031-6154fb63aedd.git",
+      "name": "[PipouJS] Backoffice staging",
+      "alias": "PipouJS-Backoffice-staging"
     }
   ]
 }

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -1,26 +1,48 @@
-name: Deploy — Production
+name: Deploy — Production (manuel)
 
+# Déclenchement 100 % manuel depuis l'onglet Actions (Run workflow).
+# Le job `gate` refuse le déploiement si aucun staging n'a été déployé
+# (tag `staging-deployed` absent) ou si le commit déployé en staging
+# n'est pas inclus dans le commit de production courant.
 on:
-  pull_request:
-    branches: [main]
-    types: [closed]
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
-  deploy-api:
-    name: Deploy API → Clever Cloud
+  gate:
+    name: Garde — un déploiement staging est requis
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Vérifier le tag staging-deployed
+        run: |
+          if ! git fetch origin 'refs/tags/staging-deployed:refs/tags/staging-deployed' 2>/dev/null; then
+            echo "::error::Aucun déploiement staging enregistré (tag 'staging-deployed' absent). Déploie d'abord le staging."
+            exit 1
+          fi
+          staged="$(git rev-parse staging-deployed)"
+          echo "Dernier commit déployé en staging : $staged"
+          if ! git merge-base --is-ancestor "$staged" HEAD; then
+            echo "::error::Le commit déployé en staging ($staged) n'est pas inclus dans ce commit de production. Promeus-le via staging → main avant de déployer en prod."
+            exit 1
+          fi
+          echo "✓ Garde franchie : le code à déployer en prod a bien été validé en staging."
 
+  deploy-api:
+    name: Deploy API → Clever Cloud
+    runs-on: ubuntu-latest
+    needs: gate
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Install Clever Tools
         run: npm install -g clever-tools
-
       - name: Deploy
         env:
           CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
@@ -30,15 +52,14 @@ jobs:
   deploy-frontend:
     name: Deploy Frontend → Clever Cloud
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true
+    needs: gate
+    environment: production
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
       - name: Install Clever Tools
         run: npm install -g clever-tools
-
       - name: Deploy
         env:
           CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
@@ -48,15 +69,14 @@ jobs:
   deploy-backoffice:
     name: Deploy Backoffice → Clever Cloud
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true
+    needs: gate
+    environment: production
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
       - name: Install Clever Tools
         run: npm install -g clever-tools
-
       - name: Deploy
         env:
           CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,26 +1,26 @@
-name: Deploy — Staging
+name: Deploy — Staging (manuel)
 
+# Déclenchement 100 % manuel depuis l'onglet Actions (Run workflow).
+# Déploie les 3 apps staging sur Clever Cloud, puis pose le tag mobile
+# `staging-deployed` sur le commit déployé — ce tag sert de garde au
+# déploiement de production (voir deploy-main.yml).
 on:
-  pull_request:
-    branches: [staging]
-    types: [closed]
+  workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write   # nécessaire pour pousser le tag staging-deployed
 
 jobs:
   deploy-api:
     name: Deploy API → Clever Cloud (staging)
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true
+    environment: staging
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
       - name: Install Clever Tools
         run: npm install -g clever-tools
-
       - name: Deploy
         env:
           CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
@@ -30,15 +30,13 @@ jobs:
   deploy-frontend:
     name: Deploy Frontend → Clever Cloud (staging)
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true
+    environment: staging
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
       - name: Install Clever Tools
         run: npm install -g clever-tools
-
       - name: Deploy
         env:
           CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
@@ -48,17 +46,29 @@ jobs:
   deploy-backoffice:
     name: Deploy Backoffice → Clever Cloud (staging)
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true
+    environment: staging
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
       - name: Install Clever Tools
         run: npm install -g clever-tools
-
       - name: Deploy
         env:
           CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
           CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
         run: clever deploy --alias PipouJS-Backoffice-staging --force
+
+  mark-staging-deployed:
+    name: Marquer le commit comme déployé en staging
+    runs-on: ubuntu-latest
+    needs: [deploy-api, deploy-frontend, deploy-backoffice]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Poser le tag staging-deployed
+        run: |
+          git tag -f staging-deployed "${{ github.sha }}"
+          git push -f origin staging-deployed
+          echo "✓ Tag staging-deployed -> ${{ github.sha }}"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,64 @@
+name: Deploy — Staging
+
+on:
+  pull_request:
+    branches: [staging]
+    types: [closed]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy-api:
+    name: Deploy API → Clever Cloud (staging)
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Clever Tools
+        run: npm install -g clever-tools
+
+      - name: Deploy
+        env:
+          CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
+          CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
+        run: clever deploy --alias PipouJS-API-staging --force
+
+  deploy-frontend:
+    name: Deploy Frontend → Clever Cloud (staging)
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Clever Tools
+        run: npm install -g clever-tools
+
+      - name: Deploy
+        env:
+          CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
+          CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
+        run: clever deploy --alias PipouJS-Front-staging --force
+
+  deploy-backoffice:
+    name: Deploy Backoffice → Clever Cloud (staging)
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Clever Tools
+        run: npm install -g clever-tools
+
+      - name: Deploy
+        env:
+          CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
+          CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
+        run: clever deploy --alias PipouJS-Backoffice-staging --force

--- a/docs/plan_deploiement.md
+++ b/docs/plan_deploiement.md
@@ -56,10 +56,12 @@ Ces trois services communiquent avec une base de données **PostgreSQL 16** et u
 | Environnement | Infrastructure | Branche Git | Déploiement |
 |---------------|----------------|-------------|-------------|
 | Développement | Local (Docker Compose) | `dev` | `npm run dev` |
-| Staging | Clever Cloud (replica prod) | `staging` | CD automatique (GitHub Actions -> Clever Cloud) |
-| Production | Clever Cloud | `main` | CD automatique (GitHub Actions -> Clever Cloud) |
+| Staging | Clever Cloud (replica prod) | `staging` | Déploiement **manuel** (GitHub Actions → Clever Cloud) |
+| Production | Clever Cloud | `main` | Déploiement **manuel + gardé** (staging requis au préalable) |
 
-Le staging est un **replica prod-like sur Clever Cloud**, déployé automatiquement à chaque merge vers `staging`. Il sert de dernière validation sur l'infra réelle (build Clever, Cellar S3, addon PostgreSQL, injection des variables) avant le merge vers `main`. La CI (build + tests) reste la première barrière sur les PR.
+Le staging est un **replica prod-like sur Clever Cloud**, déployé **manuellement** via l'onglet Actions (workflow `deploy-staging.yml`). Il sert de dernière validation sur l'infra réelle (build Clever, Cellar S3, addon PostgreSQL, injection des variables) avant la production. La CI (build + tests) reste la première barrière sur les PR.
+
+La **production** se déploie elle aussi manuellement, mais le workflow **refuse de partir tant qu'aucun déploiement staging n'a eu lieu** (voir la garde §5.5).
 
 ### 2.3 Apps Clever Cloud
 
@@ -117,14 +119,14 @@ Toute nouvelle fonctionnalité est développée sur une branche dédiée (`featu
 |-----------|--------|
 | Objectif | Validation sur infra réelle avant merge vers `main` |
 | Infrastructure | Clever Cloud (replica prod, plans minimaux) |
-| Déploiement | Automatique via `deploy-staging.yml` à chaque merge de PR vers `staging` |
+| Déploiement | **Manuel** via `deploy-staging.yml` (onglet Actions → Run workflow) |
 | Base de données | Addon PostgreSQL Clever dédié (données de seed) |
 | Stockage | Cellar S3 Clever dédié |
-| Déclencheur CD | Merge d'une PR vers `staging` |
+| Déclencheur CD | `workflow_dispatch` (manuel) |
 
 Deux barrières successives :
 1. **CI sur les PR** (build, tests unitaires, intégration, perf k6, build Docker) — empêche un merge cassé.
-2. **Déploiement staging Clever** après merge — valide ce que la CI ne peut pas tester : build Clever, Cellar S3, addon PostgreSQL managé, injection des variables d'environnement, URLs/CORS réels, HTTPS.
+2. **Déploiement staging Clever** (déclenché à la main) — valide ce que la CI ne peut pas tester : build Clever, Cellar S3, addon PostgreSQL managé, injection des variables d'environnement, URLs/CORS réels, HTTPS. Un staging réussi pose le tag `staging-deployed`, prérequis du déploiement prod.
 
 > ⚠️ Ne jamais brancher de données réelles sur le staging — uniquement des données de seed.
 
@@ -134,7 +136,7 @@ Deux barrières successives :
 |-----------|--------|
 | Objectif | Service aux utilisateurs finaux |
 | Infrastructure | Clever Cloud |
-| Déploiement | Automatique via GitHub Actions a chaque merge vers `main` |
+| Déploiement | **Manuel et gardé** via `deploy-main.yml` (staging requis au préalable) |
 | Base de données | PostgreSQL Clever Cloud (données réelles) |
 | Stockage | Cellar S3 Clever Cloud |
 | HTTPS | Géré automatiquement par Clever Cloud (Let's Encrypt) |
@@ -208,8 +210,8 @@ Si aucun commit ne justifie une nouvelle version (`chore:`, `docs:`), semantic-r
 |----------|---------|-------------|------|
 | CI | `ci.yml` | PR vers `dev`, `staging`, `main` | Build + tests complets + notification échec |
 | Docker Build | `docker-build.yml` | PR vers `staging`, `main` | Vérification image Docker backend |
-| Deploy Staging | `deploy-staging.yml` | Merge PR vers `staging` | Déploiement Clever Cloud staging (3 apps) |
-| Deploy Production | `deploy-main.yml` | Merge PR vers `main` | Déploiement Clever Cloud prod (3 apps) |
+| Deploy Staging | `deploy-staging.yml` | Manuel (`workflow_dispatch`) | Déploie les 3 apps staging + pose le tag `staging-deployed` |
+| Deploy Production | `deploy-main.yml` | Manuel (`workflow_dispatch`) | Garde (staging requis) puis déploie les 3 apps prod |
 | Release | `release.yml` | Push sur `main`, `staging`, `dev` | Tag Git + GitHub Release |
 | Dependabot | `dependabot.yml` | Tous les lundis | Mises a jour dépendances npm + actions |
 
@@ -240,7 +242,7 @@ Construit l'image Docker du backend (`backend/Dockerfile`) sans la pousser vers 
 ### 5.4 Pipeline CD Staging
 
 **Fichier :** `.github/workflows/deploy-staging.yml`
-**Déclencheur :** Merge d'une PR vers `staging` (`pull_request: [closed]` + `if: merged == true`)
+**Déclencheur :** **Manuel** (`workflow_dispatch`, onglet Actions → Run workflow)
 
 Symétrique de la prod, vers les apps staging :
 
@@ -249,18 +251,24 @@ Symétrique de la prod, vers les apps staging :
 | Deploy API | `clever deploy --alias PipouJS-API-staging --force` |
 | Deploy Frontend | `clever deploy --alias PipouJS-Front-staging --force` |
 | Deploy Backoffice | `clever deploy --alias PipouJS-Backoffice-staging --force` |
+| `mark-staging-deployed` | pose le tag mobile `staging-deployed` sur le commit déployé (après succès des 3) |
 
-Mêmes secrets `CLEVER_TOKEN` / `CLEVER_SECRET`. Nécessite que les 3 apps staging existent et soient référencées dans `.clever.json` (voir §2.3).
+Mêmes secrets `CLEVER_TOKEN` / `CLEVER_SECRET`. Nécessite que les 3 apps staging existent et soient référencées dans `.clever.json` (voir §2.3). Le job de marquage requiert `permissions: contents: write` (pour pousser le tag).
 
 ### 5.5 Pipeline CD Production
 
 **Fichier :** `.github/workflows/deploy-main.yml`
-**Déclencheur :** Merge d'une PR vers `main`
+**Déclencheur :** **Manuel** (`workflow_dispatch`)
 
-Les 3 apps se déploient en parallèle :
+Un job **`gate`** s'exécute en premier et **bloque le déploiement** si :
+- le tag `staging-deployed` n'existe pas (⇒ aucun staging déployé), ou
+- le commit pointé par `staging-deployed` n'est **pas un ancêtre** du commit de prod courant (⇒ le code à mettre en prod n'a pas transité par le staging).
+
+Ce n'est qu'une fois la garde franchie que les 3 jobs de déploiement (`needs: gate`) s'exécutent :
 
 | Job | Commande |
 |-----|----------|
+| gate | vérifie le tag `staging-deployed` + relation d'ancêtre |
 | Deploy API | `clever deploy --alias PipouJS-API --force` |
 | Deploy Frontend | `clever deploy --alias PipouJS-Front --force` |
 | Deploy Backoffice | `clever deploy --alias PipouJS-Backoffice --force` |
@@ -338,16 +346,19 @@ npm run dev:front
 | Swagger | `http://localhost:3001/api-docs` |
 | MinIO console | `http://localhost:9002` |
 
-### 7.2 Déploiement production (automatique)
+### 7.2 Déploiement (manuel, gardé)
 
-Le déploiement est entièrement automatisé :
+Le flux de validation reste par PR, mais les **déploiements sont déclenchés à la main** depuis l'onglet Actions :
 
 ```
-PR feature/* -> dev  ->  PR dev -> staging  ->  PR staging -> main  ->  Deploy Clever Cloud
-      CI valide               CI + Docker valide              CD automatique
+PR feature/* -> dev  ->  PR dev -> staging  ->  PR staging -> main
+      CI valide               CI + Docker valide
+
+Actions → "Deploy — Staging (manuel)"      → déploie staging + tag staging-deployed
+Actions → "Deploy — Production (manuel)"   → garde (staging requis) puis déploie la prod
 ```
 
-Aucune action manuelle requise en dehors de l'ouverture et du merge des PRs.
+L'ordre est imposé par la garde : **impossible de déployer la prod sans avoir déployé le staging au préalable** (sur un commit inclus dans celui de prod).
 
 ### 7.3 Déploiement manuel (fallback)
 
@@ -447,7 +458,7 @@ HTTPS géré automatiquement par Clever Cloud (Let's Encrypt).
 2. Consulter les logs : `clever logs --alias PipouJS-API`
 3. Si lié a un déploiement récent : rollback (section 7.6)
 4. Le CI crée automatiquement une issue GitHub avec le label `bug` et un lien vers les logs
-5. Corriger sur `dev` -> PR `staging` (CI) -> PR `main` (CD automatique)
+5. Corriger sur `dev` -> PR `staging` (CI) -> déploiement staging manuel -> PR `main` -> déploiement prod manuel (gardé)
 
 ---
 
@@ -460,7 +471,8 @@ HTTPS géré automatiquement par Clever Cloud (Let's Encrypt).
 | Infrastructure Clever Cloud | 3 apps + PostgreSQL + Cellar S3 |
 | Environnement local | Docker Compose (`full-local`, `front-only`) |
 | CI complet | Build + tests unitaires + intégration + perf k6 + Docker build |
-| CD automatique | `deploy-main.yml` -> Clever Cloud au merge sur `main` |
+| CD manuel staging | `deploy-staging.yml` (`workflow_dispatch`) -> 3 apps staging + tag `staging-deployed` |
+| CD manuel prod gardé | `deploy-main.yml` (`workflow_dispatch`) -> garde (staging requis) puis 3 apps prod |
 | Versioning automatique | semantic-release (alpha / beta / stable) |
 | Protection des branches | `main`, `staging`, `dev` protégées avec PR obligatoire |
 | Mises a jour dépendances | Dependabot hebdomadaire vers `dev` |
@@ -471,6 +483,7 @@ HTTPS géré automatiquement par Clever Cloud (Let's Encrypt).
 
 | Priorité | Tâche | Fichier |
 |----------|-------|---------|
+| 0 🔴 | **Secrets `CLEVER_TOKEN` / `CLEVER_SECRET`** à ajouter dans GitHub — sans eux, tout déploiement via Actions échoue | Settings → Secrets → Actions |
 | 1 | Templates issues et PR GitHub | `.github/ISSUE_TEMPLATE/`, `PULL_REQUEST_TEMPLATE.md` |
 | 2 | Plan de sécurité | `docs/plan_securite.md` |
 | 3 | Audit sécurité dépendances dans CI | Ajouter `npm audit` dans `ci.yml` |

--- a/docs/plan_deploiement.md
+++ b/docs/plan_deploiement.md
@@ -56,25 +56,29 @@ Ces trois services communiquent avec une base de données **PostgreSQL 16** et u
 | Environnement | Infrastructure | Branche Git | Déploiement |
 |---------------|----------------|-------------|-------------|
 | Développement | Local (Docker Compose) | `dev` | `npm run dev` |
-| Staging | CI GitHub Actions uniquement | `staging` | CI automatique (pas de cloud) |
+| Staging | Clever Cloud (replica prod) | `staging` | CD automatique (GitHub Actions -> Clever Cloud) |
 | Production | Clever Cloud | `main` | CD automatique (GitHub Actions -> Clever Cloud) |
 
-Le staging ne déploie **pas** sur un serveur distant — il sert de barrière CI (build + tests complets) avant d'autoriser le merge vers `main`. Cela évite de doubler les coûts d'hébergement.
+Le staging est un **replica prod-like sur Clever Cloud**, déployé automatiquement à chaque merge vers `staging`. Il sert de dernière validation sur l'infra réelle (build Clever, Cellar S3, addon PostgreSQL, injection des variables) avant le merge vers `main`. La CI (build + tests) reste la première barrière sur les PR.
 
-### 2.3 Apps Clever Cloud (production uniquement)
+### 2.3 Apps Clever Cloud
 
-| App | Type | Alias |
-|-----|------|-------|
-| **API** | Node.js | `PipouJS-API` |
-| **Frontend** | Static | `PipouJS-Front` |
-| **Backoffice** | Static | `PipouJS-Backoffice` |
+Deux jeux d'apps, un par environnement cloud :
 
-**Add-ons liés a l'API :**
+| App | Type | Alias prod | Alias staging |
+|-----|------|------------|---------------|
+| **API** | Node.js | `PipouJS-API` | `PipouJS-API-staging` |
+| **Frontend** | Static | `PipouJS-Front` | `PipouJS-Front-staging` |
+| **Backoffice** | Static | `PipouJS-Backoffice` | `PipouJS-Backoffice-staging` |
+
+**Add-ons liés a l'API (un jeu par environnement) :**
 
 | Add-on | Plan | Usage |
 |--------|------|-------|
 | PostgreSQL | dev | Base de données principale |
 | Cellar S3 | S | Stockage des fichiers uploadés |
+
+> 🔜 **Prérequis staging à créer côté Clever Cloud :** 3 apps (`PipouJS-API-staging`, `PipouJS-Front-staging`, `PipouJS-Backoffice-staging`) + leurs add-ons PostgreSQL et Cellar dédiés, avec les mêmes variables d'environnement que la prod (voir [deploiement_clever_cloud.md](deploiement_clever_cloud.md)). Les 3 alias staging doivent ensuite être ajoutés à `.clever.json` pour que le workflow `deploy-staging.yml` puisse les cibler. Plans minimaux recommandés (Nano / Postgres dev / Cellar S) ; apps arrêtées hors période de test pour limiter les coûts.
 
 ### 2.4 Environnement local (Docker Compose)
 
@@ -111,13 +115,18 @@ Toute nouvelle fonctionnalité est développée sur une branche dédiée (`featu
 
 | Paramètre | Valeur |
 |-----------|--------|
-| Objectif | Validation complète avant merge vers `main` |
-| Infrastructure | GitHub Actions uniquement — pas de déploiement cloud |
-| Base de données | PostgreSQL éphémère (GitHub Actions services) |
-| Stockage | MinIO éphémère (GitHub Actions services) |
-| Déclencheur | PR vers `staging` |
+| Objectif | Validation sur infra réelle avant merge vers `main` |
+| Infrastructure | Clever Cloud (replica prod, plans minimaux) |
+| Déploiement | Automatique via `deploy-staging.yml` à chaque merge de PR vers `staging` |
+| Base de données | Addon PostgreSQL Clever dédié (données de seed) |
+| Stockage | Cellar S3 Clever dédié |
+| Déclencheur CD | Merge d'une PR vers `staging` |
 
-Le staging est une **barrière CI**. La validation couvre : build, tests unitaires, tests d'intégration, tests de performance k6 et build Docker.
+Deux barrières successives :
+1. **CI sur les PR** (build, tests unitaires, intégration, perf k6, build Docker) — empêche un merge cassé.
+2. **Déploiement staging Clever** après merge — valide ce que la CI ne peut pas tester : build Clever, Cellar S3, addon PostgreSQL managé, injection des variables d'environnement, URLs/CORS réels, HTTPS.
+
+> ⚠️ Ne jamais brancher de données réelles sur le staging — uniquement des données de seed.
 
 ### 3.3 Environnement de production (branche `main`)
 
@@ -199,7 +208,8 @@ Si aucun commit ne justifie une nouvelle version (`chore:`, `docs:`), semantic-r
 |----------|---------|-------------|------|
 | CI | `ci.yml` | PR vers `dev`, `staging`, `main` | Build + tests complets + notification échec |
 | Docker Build | `docker-build.yml` | PR vers `staging`, `main` | Vérification image Docker backend |
-| Deploy Production | `deploy-main.yml` | Merge PR vers `main` | Déploiement Clever Cloud (3 apps) |
+| Deploy Staging | `deploy-staging.yml` | Merge PR vers `staging` | Déploiement Clever Cloud staging (3 apps) |
+| Deploy Production | `deploy-main.yml` | Merge PR vers `main` | Déploiement Clever Cloud prod (3 apps) |
 | Release | `release.yml` | Push sur `main`, `staging`, `dev` | Tag Git + GitHub Release |
 | Dependabot | `dependabot.yml` | Tous les lundis | Mises a jour dépendances npm + actions |
 
@@ -227,7 +237,22 @@ Si un job échoue : PR bloquée + issue GitHub créée automatiquement avec le l
 
 Construit l'image Docker du backend (`backend/Dockerfile`) sans la pousser vers un registry. Vérifie que le Dockerfile est valide avant chaque déploiement potentiel.
 
-### 5.4 Pipeline CD Production
+### 5.4 Pipeline CD Staging
+
+**Fichier :** `.github/workflows/deploy-staging.yml`
+**Déclencheur :** Merge d'une PR vers `staging` (`pull_request: [closed]` + `if: merged == true`)
+
+Symétrique de la prod, vers les apps staging :
+
+| Job | Commande |
+|-----|----------|
+| Deploy API | `clever deploy --alias PipouJS-API-staging --force` |
+| Deploy Frontend | `clever deploy --alias PipouJS-Front-staging --force` |
+| Deploy Backoffice | `clever deploy --alias PipouJS-Backoffice-staging --force` |
+
+Mêmes secrets `CLEVER_TOKEN` / `CLEVER_SECRET`. Nécessite que les 3 apps staging existent et soient référencées dans `.clever.json` (voir §2.3).
+
+### 5.5 Pipeline CD Production
 
 **Fichier :** `.github/workflows/deploy-main.yml`
 **Déclencheur :** Merge d'une PR vers `main`
@@ -247,7 +272,7 @@ Les 3 apps se déploient en parallèle :
 | `CLEVER_TOKEN` | Token d'authentification Clever Cloud |
 | `CLEVER_SECRET` | Secret Clever Cloud |
 
-### 5.5 Mises a jour automatiques des dépendances (Dependabot)
+### 5.6 Mises a jour automatiques des dépendances (Dependabot)
 
 **Fichier :** `.github/dependabot.yml`
 **Déclencheur :** Tous les lundis a 9h (Europe/Paris)

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "e2e"
   ],
   "scripts": {
-    "install": "cd ${CC_APP_FOLDER:-.} && npm install",
     "start": "cd ${CC_APP_FOLDER:-.} && npm start",
     "deploy": "cd ${CC_APP_FOLDER:-.} && npm run deploy",
     "dev": "docker compose --profile full-local up --build",


### PR DESCRIPTION
Promotion en production du dispositif de déploiement continu Clever Cloud (validé sur `dev` puis `staging`).

## Contenu
- Workflows de déploiement **100 % manuels** (`workflow_dispatch`) : `deploy-staging.yml` et `deploy-main.yml`.
- **Garde staging → prod** : tag `staging-deployed` posé par un staging réussi, vérifié par le job `gate` du workflow prod.
- 3 alias staging dans `.clever.json`.
- Fix build : suppression du script npm `install` racine (boucle infinie).
- Doc `plan_deploiement.md` à jour.

## Effet de ce merge
Amène les workflows sur `main` → les boutons **Run workflow** deviennent disponibles dans l'onglet Actions. **Aucun déploiement n'est déclenché par ce merge** (déploiements manuels).

🤖 Generated with [Claude Code](https://claude.com/claude-code)